### PR TITLE
Add artifact-type to ecosystems-cert-preflight-checks to ensure task success

### DIFF
--- a/.tekton/operator-bundle-1-0-pull-request.yaml
+++ b/.tekton/operator-bundle-1-0-pull-request.yaml
@@ -347,6 +347,8 @@ spec:
           value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:df8a25a3431a70544172ed4844f9d0c6229d39130633960729f825a031a7dea9
         - name: kind
           value: task
+        - name: artifact-type
+          value: operatorbundle
         resolver: bundles
       when:
       - input: $(params.skip-checks)

--- a/.tekton/operator-bundle-1-0-push.yaml
+++ b/.tekton/operator-bundle-1-0-push.yaml
@@ -344,6 +344,8 @@ spec:
           value: quay.io/konflux-ci/tekton-catalog/task-ecosystem-cert-preflight-checks:0.1@sha256:df8a25a3431a70544172ed4844f9d0c6229d39130633960729f825a031a7dea9
         - name: kind
           value: task
+        - name: artifact-type
+          value: operatorbundle
         resolver: bundles
       when:
       - input: $(params.skip-checks)


### PR DESCRIPTION
New parameter for the task allows the definition of the artifact-type, which should fix the issue with the bundle that is caused by the fact that the image is based from scratch and that's not a valid source image (or at least that's what my experience of how it used to fail tells me). Depends on #39 