### PR TITLE
Switch to a newer controller-gen version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -265,7 +265,7 @@ $(LOCALBIN):
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.3.0
-CONTROLLER_TOOLS_VERSION ?= v0.17.2
+CONTROLLER_TOOLS_VERSION ?= envtest-v1.33.0-alpha.2
 ENVTEST_VERSION ?= release-0.17
 GOLANGCI_LINT_VERSION ?= v1.64.6
 # update for major version updates to YQ_VERSION!

--- a/config/crd/bases/scale.storage.openshift.io_localvolumediscoveries.yaml
+++ b/config/crd/bases/scale.storage.openshift.io_localvolumediscoveries.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303095116-ab66d59f6d78
   name: localvolumediscoveries.scale.storage.openshift.io
 spec:
   group: scale.storage.openshift.io

--- a/config/crd/bases/scale.storage.openshift.io_localvolumediscoveryresults.yaml
+++ b/config/crd/bases/scale.storage.openshift.io_localvolumediscoveryresults.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303095116-ab66d59f6d78
   name: localvolumediscoveryresults.scale.storage.openshift.io
 spec:
   group: scale.storage.openshift.io

--- a/config/crd/bases/scale.storage.openshift.io_storagescales.yaml
+++ b/config/crd/bases/scale.storage.openshift.io_storagescales.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.17.2
+    controller-gen.kubebuilder.io/version: v0.17.3-0.20250303095116-ab66d59f6d78
   name: storagescales.scale.storage.openshift.io
 spec:
   group: scale.storage.openshift.io


### PR DESCRIPTION
When we updated to github.com/openshift/api v0.0.0-20250320115527-3aa9dd5b9002 via PR #43
we now get build failures like the following:

    openshift-storage-scale-operator/bin/controller-gen-v0.16.5 rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
    openshift-storage-scale-operator/vendor/github.com/openshift/api/operator/v1/types.go:261:1: unknown argument "optionalOldSelf" (at <input>:1:141)

The reason is that openshift-api introduced this new optionalOldSelf
field via commit 6b76c18eb93ca14e50e219b5901538a8adbad6e5 but our
controller-gen version (v0.17.2) does not have support for it yet.

For now let's switch to this later version of controller-gen which has
support for this as it includes controller-gen commit 5e25270c327822203fe7fd6ed15f1b8d4380914b
which introduced this optionalOldSelf.
