### PR TITLE
Use ubi10-beta as base image for devicefinder instead of support-tools

### DIFF
--- a/devicefinder.Dockerfile
+++ b/devicefinder.Dockerfile
@@ -7,7 +7,8 @@ COPY . .
 
 RUN make build-devicefinder
 
-FROM registry.redhat.io/rhel9/support-tools@sha256:bcf55d238c144fb0686e658d18f7da96b33997ab8535e2e300767e1518c0ca23
+# Change this once ubi10 moves out of beta
+FROM registry.redhat.io/ubi10-beta/ubi@sha256:f817eb70b083c93b4d6b47e1daae292d662e3427f5e73c5e8f513695e5afc7cc
 
 COPY --from=builder /workspace/_output/bin/devicefinder /usr/bin/
 


### PR DESCRIPTION
@mbaldessari @darkdoc PTAL.