### PR TITLE
Bump quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta manually

### DIFF
--- a/.tekton/console-plugin-1-0-pull-request.yaml
+++ b/.tekton/console-plugin-1-0-pull-request.yaml
@@ -231,7 +231,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ce47dff42110bb08c89e0f8e3be427b3e9edaec83868b12275a646b7b64d7b68
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d17ea0d7f1b45bc7f3eb165618ed7d935a871977d87ea2ea856769bc0640aefd
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/console-plugin-1-0-push.yaml
+++ b/.tekton/console-plugin-1-0-push.yaml
@@ -228,7 +228,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ce47dff42110bb08c89e0f8e3be427b3e9edaec83868b12275a646b7b64d7b68
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d17ea0d7f1b45bc7f3eb165618ed7d935a871977d87ea2ea856769bc0640aefd
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/controller-rhel9-operator-1-0-pull-request.yaml
+++ b/.tekton/controller-rhel9-operator-1-0-pull-request.yaml
@@ -229,7 +229,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ce47dff42110bb08c89e0f8e3be427b3e9edaec83868b12275a646b7b64d7b68
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d17ea0d7f1b45bc7f3eb165618ed7d935a871977d87ea2ea856769bc0640aefd
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/controller-rhel9-operator-1-0-push.yaml
+++ b/.tekton/controller-rhel9-operator-1-0-push.yaml
@@ -226,7 +226,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ce47dff42110bb08c89e0f8e3be427b3e9edaec83868b12275a646b7b64d7b68
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d17ea0d7f1b45bc7f3eb165618ed7d935a871977d87ea2ea856769bc0640aefd
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/devicefinder-1-0-pull-request.yaml
+++ b/.tekton/devicefinder-1-0-pull-request.yaml
@@ -228,7 +228,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ce47dff42110bb08c89e0f8e3be427b3e9edaec83868b12275a646b7b64d7b68
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d17ea0d7f1b45bc7f3eb165618ed7d935a871977d87ea2ea856769bc0640aefd
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/devicefinder-1-0-push.yaml
+++ b/.tekton/devicefinder-1-0-push.yaml
@@ -225,7 +225,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ce47dff42110bb08c89e0f8e3be427b3e9edaec83868b12275a646b7b64d7b68
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d17ea0d7f1b45bc7f3eb165618ed7d935a871977d87ea2ea856769bc0640aefd
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/must-gather-1-0-pull-request.yaml
+++ b/.tekton/must-gather-1-0-pull-request.yaml
@@ -224,7 +224,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ce47dff42110bb08c89e0f8e3be427b3e9edaec83868b12275a646b7b64d7b68
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d17ea0d7f1b45bc7f3eb165618ed7d935a871977d87ea2ea856769bc0640aefd
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/must-gather-1-0-push.yaml
+++ b/.tekton/must-gather-1-0-push.yaml
@@ -221,7 +221,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ce47dff42110bb08c89e0f8e3be427b3e9edaec83868b12275a646b7b64d7b68
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d17ea0d7f1b45bc7f3eb165618ed7d935a871977d87ea2ea856769bc0640aefd
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/operator-bundle-1-0-pull-request.yaml
+++ b/.tekton/operator-bundle-1-0-pull-request.yaml
@@ -223,7 +223,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ce47dff42110bb08c89e0f8e3be427b3e9edaec83868b12275a646b7b64d7b68
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d17ea0d7f1b45bc7f3eb165618ed7d935a871977d87ea2ea856769bc0640aefd
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/operator-bundle-1-0-push.yaml
+++ b/.tekton/operator-bundle-1-0-push.yaml
@@ -220,7 +220,7 @@ spec:
         - name: name
           value: buildah-oci-ta
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:ce47dff42110bb08c89e0f8e3be427b3e9edaec83868b12275a646b7b64d7b68
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah-oci-ta:0.4@sha256:d17ea0d7f1b45bc7f3eb165618ed7d935a871977d87ea2ea856769bc0640aefd
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Just to make konflux stop complaining about a deprecation warning in may