### PR TITLE
Fix unit tests after migrating from operatorv1.OperatorCondition struct

### DIFF
--- a/config/crd/bases/scale.storage.openshift.io_localvolumediscoveries.yaml
+++ b/config/crd/bases/scale.storage.openshift.io_localvolumediscoveries.yaml
@@ -180,7 +180,7 @@ spec:
                 items:
                   description: |-
                     This is a copy from https://github.com/kubernetes/apimachinery/blob/e8a77bd768fd1419e9b3b48a28dd2c6458733a20/pkg/apis/meta/v1/types.go#L1589
-                    Removed the Reason field because we don't use it, otherwise we'd be reusing the struct provided by the apimachinery
+                    Removed the Reason and ObservedGeneration field because we don't use them, and Reason is a mandatory field.
 
                     Condition contains details for one aspect of the current state of this API Resource.
                   properties:

--- a/config/crd/bases/scale.storage.openshift.io_storagescales.yaml
+++ b/config/crd/bases/scale.storage.openshift.io_storagescales.yaml
@@ -87,7 +87,7 @@ spec:
                 items:
                   description: |-
                     This is a copy from https://github.com/kubernetes/apimachinery/blob/e8a77bd768fd1419e9b3b48a28dd2c6458733a20/pkg/apis/meta/v1/types.go#L1589
-                    Removed the Reason field because we don't use it, otherwise we'd be reusing the struct provided by the apimachinery
+                    Removed the Reason and ObservedGeneration field because we don't use them, and Reason is a mandatory field.
 
                     Condition contains details for one aspect of the current state of this API Resource.
                   properties:

--- a/internal/controller/localvolumediscovery/localvolumediscovery_controller.go
+++ b/internal/controller/localvolumediscovery/localvolumediscovery_controller.go
@@ -113,7 +113,7 @@ func (r *LocalVolumeDiscoveryReconciler) Reconcile(ctx context.Context, request 
 		if err != nil {
 			return ctrl.Result{}, err
 		}
-		return waitForRequeueIfDaemonsNotReady, fmt.Errorf("%s", message)
+		return waitForRequeueIfDaemonsNotReady, nil
 	} else if desiredDaemons != readyDaemons {
 		message := fmt.Sprintf("running %d out of %d discovery daemons", readyDaemons, desiredDaemons)
 		err := r.updateDiscoveryStatus(ctx, instance, operatorv1.OperatorStatusTypeProgressing, message,

--- a/internal/controller/localvolumediscovery/localvolumediscovery_controller_test.go
+++ b/internal/controller/localvolumediscovery/localvolumediscovery_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	localv1alpha1 "github.com/openshift-storage-scale/openshift-storage-scale-operator/api/v1alpha1"
-	operatorv1 "github.com/openshift/api/operator/v1"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
@@ -148,7 +147,7 @@ func TestDiscoveryReconciler(t *testing.T) {
 		discoveryReadyDaemonsCount   int32
 		expectedPhase                localv1alpha1.DiscoveryPhase
 		conditionType                string
-		conditionStatus              operatorv1.ConditionStatus
+		conditionStatus              metav1.ConditionStatus
 	}{
 		{
 			label:                        "case 1", // all the desired discovery daemonset pods are running
@@ -157,7 +156,7 @@ func TestDiscoveryReconciler(t *testing.T) {
 			discoveryReadyDaemonsCount:   1,
 			expectedPhase:                localv1alpha1.Discovering,
 			conditionType:                "Available",
-			conditionStatus:              operatorv1.ConditionTrue,
+			conditionStatus:              metav1.ConditionTrue,
 		},
 		{
 			label:                        "case 2", // all the desired discovery daemonset pods are running
@@ -166,7 +165,7 @@ func TestDiscoveryReconciler(t *testing.T) {
 			discoveryReadyDaemonsCount:   100,
 			expectedPhase:                localv1alpha1.Discovering,
 			conditionType:                "Available",
-			conditionStatus:              operatorv1.ConditionTrue,
+			conditionStatus:              metav1.ConditionTrue,
 		},
 		{
 			label:                        "case 3", // ready discovery daemonset pods are less than the desired count
@@ -175,7 +174,7 @@ func TestDiscoveryReconciler(t *testing.T) {
 			discoveryReadyDaemonsCount:   80,
 			expectedPhase:                localv1alpha1.Discovering,
 			conditionType:                "Progressing",
-			conditionStatus:              operatorv1.ConditionFalse,
+			conditionStatus:              metav1.ConditionFalse,
 		},
 		{
 			label:                        "case 4", // no discovery daemonset pods are running
@@ -184,7 +183,7 @@ func TestDiscoveryReconciler(t *testing.T) {
 			discoveryReadyDaemonsCount:   0,
 			expectedPhase:                localv1alpha1.DiscoveryFailed,
 			conditionType:                "Degraded",
-			conditionStatus:              operatorv1.ConditionFalse,
+			conditionStatus:              metav1.ConditionFalse,
 		},
 
 		{
@@ -194,7 +193,7 @@ func TestDiscoveryReconciler(t *testing.T) {
 			discoveryReadyDaemonsCount:   0,
 			expectedPhase:                localv1alpha1.DiscoveryFailed,
 			conditionType:                "Degraded",
-			conditionStatus:              operatorv1.ConditionFalse,
+			conditionStatus:              metav1.ConditionFalse,
 		},
 	}
 
@@ -229,7 +228,7 @@ func TestDiscoveryReconciler(t *testing.T) {
 		}
 		fakeReconciler := newFakeLocalVolumeDiscoveryReconciler(t, objects...)
 		_, err := fakeReconciler.Reconcile(context.TODO(), req)
-		assert.NoError(t, err)
+		assert.NoError(t, err, tc.label)
 		err = fakeReconciler.Client.Get(context.TODO(), types.NamespacedName{Name: discoveryObj.Name, Namespace: discoveryObj.Namespace}, discoveryObj)
 		assert.NoError(t, err)
 		assert.Equalf(t, tc.expectedPhase, discoveryObj.Status.Phase, "[%s] invalid phase", tc.label)


### PR DESCRIPTION
@mbaldessari @darkdoc PTAL.

TL;DR the tests failed because we started checking for the error coming from the `Reconcile` call during our linting fixing attempts. Originally, the returning error from the `Reconcile` call was ignored:
https://github.com/openshift-storage-scale/openshift-storage-scale-operator/blob/d57cfdd699b43118d1bbd25f66fd1b55c98244e8/internal/controller/localvolumediscovery/localvolumediscovery_controller_test.go#L232-L233

And then we started evaluating it, as it should've been done in the first place:
https://github.com/openshift-storage-scale/openshift-storage-scale-operator/blame/93dcd16bd485ea8cb80b9f6692c1d5b9a8752a01/internal/controller/localvolumediscovery/localvolumediscovery_controller_test.go#L232

What I've changed is [not to return an error](https://github.com/openshift-storage-scale/openshift-storage-scale-operator/pull/117/files#diff-6daf950cfdac008f017418c2ac7f84bce2db987cbaaee9b69a98d17985b09317L116) if the status update doesn't return an error and we are just requeuing the event for further reconciliation. I'd say that the desired daemons not being as expected is not really an error, just a timing issue :)

The changes to the yamls are leftovers from running make manifests/build...