### PR TITLE
Keep operatorframework.io/initialization-resource in sync

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -122,6 +122,10 @@ help: ## Display this help.
 .PHONY: manifests
 manifests: controller-gen ## Generate WebhookConfiguration, ClusterRole and CustomResourceDefinition objects.
 	$(CONTROLLER_GEN) rbac:roleName=manager-role crd webhook paths="./..." output:crd:artifacts:config=config/crd/bases
+	# This reads config/samples/scale_v1alpha1_storagescale.yaml and keeps it in sync
+	# with the initialization-resource
+	sed -i "s|^\(.*operatorframework.io/initialization-resource:\).*|\1 '$$(yq -o=json -I=0 config/samples/scale_v1alpha1_storagescale.yaml)'|" config/manifests/bases/openshift-storage-scale-operator.clusterserviceversion.yaml
+
 
 .PHONY: generate
 generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and DeepCopyObject method implementations.

--- a/config/manifests/bases/openshift-storage-scale-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-storage-scale-operator.clusterserviceversion.yaml
@@ -15,7 +15,7 @@ metadata:
     features.operators.openshift.io/token-auth-aws: "false"
     features.operators.openshift.io/token-auth-azure: "false"
     features.operators.openshift.io/token-auth-gcp: "false"
-    operatorframework.io/initialization-resource: '{"apiVersion":"scale.storage.openshift.io/v1alpha1","kind":"StorageScale","metadata":{"name":"storagescale-sample","namespace":"openshift-storage-scale"},"spec":{"ibm_cnsa_version":"v5.2.2.1"}}'
+    operatorframework.io/initialization-resource: '{"apiVersion":"scale.storage.openshift.io/v1alpha1","kind":"StorageScale","metadata":{"name":"storagescale-sample"},"spec":{"ibm_cnsa_version":"v5.2.2.1","mco_config":{"create":true,"labels":{"machineconfiguration.openshift.io/role":"worker"}},"ibm_cnsa_cluster":{"create":true,"daemon_nodeSelector":{"node-role.kubernetes.io/worker":""}}}}'
     operatorframework.io/suggested-namespace: openshift-storage-scale
     operators.openshift.io/valid-subscription: '["Openshift Container Platform"]'
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.scale.storage.openshift.io","localvolumediscoveries.scale.storage.openshift.io"]'


### PR DESCRIPTION
We add a single yq/sed command to make sure we sync the content from
config/samples/scale_v1alpha1_storagescale.yaml into the
operatorframework.io/initialization-resource.

We do this because otherwise a user will get different values depending
on where he clicks in the UI when creating the StorageScale CR.
(The normal UI for it vs the "required Storage button")

We add it to the manifests target as any of the early targets will do.

We use sed for the replacement because using yq triggers a bunch of
forced reindentation which we do not want at this point: yq forces it
to be two spaces everywhere, but the bundle reverts that in the bundles.
So I prefer to keep this a bit smaller/simpler at this time.
