### PR TITLE
Use component names sans version in the labels found in the bundle's konflux Dockerfile so that they can be retrieved by the release script to check if the sha matches the sha in the snapshot

### DIFF
--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -21,10 +21,10 @@ RUN \
 
 FROM scratch
 
-LABEL nudge.operator="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/controller-rhel9-operator@sha256:50bb08bc3df8801417e7e4c22485c5073b8eb6f471c28093015993f7e093637c"
-LABEL nudge.devicefinder="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/devicefinder-rhel9@sha256:58ce8e008b8a14d98ff3ff1b3ae951c946aa1e3ebc6930d97dc7e31389368646"
-LABEL nudge.console="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-console-plugin-rhel9@sha256:24c76455113ff27b4c2bb50d98a0042d59c8680d610b0c278dc6c268b8830270"
-LABEL nudge.must_gather="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-must-gather-rhel9@sha256:c701119180467e377cdffb0df1d24cb6eb7c68999d3d375acd24d357af84979d"
+LABEL controller-rhel9-operator="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/controller-rhel9-operator@sha256:50bb08bc3df8801417e7e4c22485c5073b8eb6f471c28093015993f7e093637c"
+LABEL devicefinder="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/devicefinder-rhel9@sha256:58ce8e008b8a14d98ff3ff1b3ae951c946aa1e3ebc6930d97dc7e31389368646"
+LABEL console-plugin="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-console-plugin-rhel9@sha256:24c76455113ff27b4c2bb50d98a0042d59c8680d610b0c278dc6c268b8830270"
+LABEL must-gather="registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-must-gather-rhel9@sha256:c701119180467e377cdffb0df1d24cb6eb7c68999d3d375acd24d357af84979d"
 
 COPY --from=builder /repo/build/manifests /manifests/
 COPY --from=builder /repo/build/metadata /metadata/


### PR DESCRIPTION
Signed-off-by: Jordi Gil <jgil@redhat.com>
