### PR TITLE
Add relatedImages to CSV to support disconnected environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ go.work
 bundle_tmp*/
 
 must-gather.local.*/
+
+build/*

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
-BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
+BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL) --use-image-digests
 
 BUNDLE_CONTAINERFILE_TEMPLATE ?= new-bundle.Dockerfile
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ ifneq ($(origin CHANNELS), undefined)
 BUNDLE_CHANNELS := --channels=$(CHANNELS)
 endif
 
+USE_IMAGE_DIGESTS ?= --use-image-digests
+
 # DEFAULT_CHANNEL defines the default channel used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
@@ -27,7 +29,7 @@ endif
 ifneq ($(origin DEFAULT_CHANNEL), undefined)
 BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
 endif
-BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL) --use-image-digests
+BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL) $(USE_IMAGE_DIGESTS)
 
 BUNDLE_CONTAINERFILE_TEMPLATE ?= new-bundle.Dockerfile
 # IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.

--- a/bundle.konflux.Dockerfile
+++ b/bundle.konflux.Dockerfile
@@ -16,7 +16,8 @@ RUN \
         --version $(cat VERSION.txt) \
         --output-dir build \
         --channels development \
-        --default-channel development && \
+        --default-channel development \
+        --use-image-digests && \
     operator-sdk bundle validate ./build
 
 FROM scratch

--- a/bundle/manifests/openshift-storage-scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-storage-scale-operator.clusterserviceversion.yaml
@@ -28,8 +28,7 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    console.openshift.io/plugins: '["openshift-storage-scale-operator-console-plugin"]'
-    createdAt: "2025-04-04T17:50:21Z"
+    createdAt: "2025-04-04T18:38:43Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -408,6 +407,15 @@ spec:
                 - patch
                 - watch
             - apiGroups:
+                - operator.openshift.io
+              resources:
+                - consoles
+              verbs:
+                - get
+                - list
+                - update
+                - watch
+            - apiGroups:
                 - policy
               resources:
                 - poddisruptionbudgets
@@ -661,7 +669,7 @@ spec:
                   app.kubernetes.io/component: openshift-storage-scale-operator-console-plugin
               spec:
                 containers:
-                  - image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-console-plugin-rhel9@sha256:f75874d3a4dcd4fd565b795e2884b7c5426600a3fb31ec9b98c3db905a4700fd
+                  - image: quay.io/openshift-storage-scale/openshift-storage-scale-console@sha256:35cea907a7126af371dc1f0746fffc5a76e6bc0399a5a35a23c881ef1421f6e7
                     name: openshift-storage-scale-operator-console-plugin
                     ports:
                       - containerPort: 9443
@@ -718,10 +726,10 @@ spec:
                           fieldRef:
                             fieldPath: metadata.namespace
                       - name: RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-DEVICEFINDER
-                        value: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/devicefinder-rhel9@sha256:58ce8e008b8a14d98ff3ff1b3ae951c946aa1e3ebc6930d97dc7e31389368646
+                        value: quay.io/openshift-storage-scale/openshift-storage-scale-devicefinder@sha256:5bed543a4bb567a1cd8a589444b6ceaa3815705829c42ecd986d5b65a47862f3
                       - name: RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-MUST-GATHER
-                        value: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-must-gather-rhel9@sha256:c701119180467e377cdffb0df1d24cb6eb7c68999d3d375acd24d357af84979d
-                    image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/controller-rhel9-operator@sha256:b9f77694996d15790cd9f0aac54f52218f9eac31b5cefa0f0144878b71435082
+                        value: quay.io/openshift-storage-scale/openshift-storage-scale-must-gather@sha256:03db023ac2d725f995976fdd8c463e916c70f44a3bca13f0dd7fc12c6a846dd5
+                    image: quay.io/openshift-storage-scale/openshift-storage-scale-operator@sha256:22c18f4e7552d8c3430db96b01eab117e01063e0f5a8baf0fdd5f4d4b762a2ed
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -847,13 +855,13 @@ spec:
   provider:
     name: Storage Scale Team
   relatedImages:
-    - image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/devicefinder-rhel9@sha256:58ce8e008b8a14d98ff3ff1b3ae951c946aa1e3ebc6930d97dc7e31389368646
+    - image: quay.io/openshift-storage-scale/openshift-storage-scale-devicefinder@sha256:5bed543a4bb567a1cd8a589444b6ceaa3815705829c42ecd986d5b65a47862f3
       name: openshift-storage-scale-operator-devicefinder
-    - image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-must-gather-rhel9@sha256:c701119180467e377cdffb0df1d24cb6eb7c68999d3d375acd24d357af84979d
+    - image: quay.io/openshift-storage-scale/openshift-storage-scale-must-gather@sha256:03db023ac2d725f995976fdd8c463e916c70f44a3bca13f0dd7fc12c6a846dd5
       name: openshift-storage-scale-operator-must-gather
-    - image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-console-plugin-rhel9@sha256:f75874d3a4dcd4fd565b795e2884b7c5426600a3fb31ec9b98c3db905a4700fd
+    - image: quay.io/openshift-storage-scale/openshift-storage-scale-console@sha256:35cea907a7126af371dc1f0746fffc5a76e6bc0399a5a35a23c881ef1421f6e7
       name: openshift-storage-scale-operator-console-plugin
-    - image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/controller-rhel9-operator@sha256:b9f77694996d15790cd9f0aac54f52218f9eac31b5cefa0f0144878b71435082
+    - image: quay.io/openshift-storage-scale/openshift-storage-scale-operator@sha256:22c18f4e7552d8c3430db96b01eab117e01063e0f5a8baf0fdd5f4d4b762a2ed
       name: manager
     - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:29201e85bd41642b72c7c0ce915e40aad90823d0efc3e7bbab9c351c92c74341
       name: kube-rbac-proxy

--- a/bundle/manifests/openshift-storage-scale-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/openshift-storage-scale-operator.clusterserviceversion.yaml
@@ -28,7 +28,8 @@ metadata:
         }
       ]
     capabilities: Basic Install
-    createdAt: "2025-04-02T20:39:25Z"
+    console.openshift.io/plugins: '["openshift-storage-scale-operator-console-plugin"]'
+    createdAt: "2025-04-04T17:50:21Z"
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "true"
@@ -41,7 +42,8 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/initialization-resource: '{"apiVersion":"scale.storage.openshift.io/v1alpha1","kind":"StorageScale","metadata":{"name":"storagescale-sample"},"spec":{"ibm_cnsa_version":"v5.2.2.1","mco_config":{"create":true,"labels":{"machineconfiguration.openshift.io/role":"worker"}},"ibm_cnsa_cluster":{"create":true,"daemon_nodeSelector":{"node-role.kubernetes.io/worker":""}}}}'
     operatorframework.io/suggested-namespace: openshift-storage-scale
-    operators.openshift.io/valid-subscription: '["Openshift Container Platform"]'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/valid-subscription: '["Openshift Container Platform","OpenShift Virtualization Engine"]'
     operators.operatorframework.io/builder: operator-sdk-v1.39.1
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.scale.storage.openshift.io","localvolumediscoveries.scale.storage.openshift.io"]'
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
@@ -659,7 +661,7 @@ spec:
                   app.kubernetes.io/component: openshift-storage-scale-operator-console-plugin
               spec:
                 containers:
-                  - image: quay.io/openshift-storage-scale/openshift-storage-scale-console:0.0.5
+                  - image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-console-plugin-rhel9@sha256:f75874d3a4dcd4fd565b795e2884b7c5426600a3fb31ec9b98c3db905a4700fd
                     name: openshift-storage-scale-operator-console-plugin
                     ports:
                       - containerPort: 9443
@@ -715,9 +717,11 @@ spec:
                         valueFrom:
                           fieldRef:
                             fieldPath: metadata.namespace
-                      - name: DEVICEFINDER_IMAGE
-                        value: quay.io/openshift-storage-scale/openshift-storage-scale-devicefinder:0.0.5
-                    image: quay.io/openshift-storage-scale/openshift-storage-scale-operator:0.0.5
+                      - name: RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-DEVICEFINDER
+                        value: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/devicefinder-rhel9@sha256:58ce8e008b8a14d98ff3ff1b3ae951c946aa1e3ebc6930d97dc7e31389368646
+                      - name: RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-MUST-GATHER
+                        value: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-must-gather-rhel9@sha256:c701119180467e377cdffb0df1d24cb6eb7c68999d3d375acd24d357af84979d
+                    image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/controller-rhel9-operator@sha256:b9f77694996d15790cd9f0aac54f52218f9eac31b5cefa0f0144878b71435082
                     livenessProbe:
                       httpGet:
                         path: /healthz
@@ -842,6 +846,17 @@ spec:
   minKubeVersion: 1.23.0
   provider:
     name: Storage Scale Team
+  relatedImages:
+    - image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/devicefinder-rhel9@sha256:58ce8e008b8a14d98ff3ff1b3ae951c946aa1e3ebc6930d97dc7e31389368646
+      name: openshift-storage-scale-operator-devicefinder
+    - image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-must-gather-rhel9@sha256:c701119180467e377cdffb0df1d24cb6eb7c68999d3d375acd24d357af84979d
+      name: openshift-storage-scale-operator-must-gather
+    - image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/storage-scale-operator-console-plugin-rhel9@sha256:f75874d3a4dcd4fd565b795e2884b7c5426600a3fb31ec9b98c3db905a4700fd
+      name: openshift-storage-scale-operator-console-plugin
+    - image: registry.stage.redhat.io/openshift-storage-scale-operator-tech-preview/controller-rhel9-operator@sha256:b9f77694996d15790cd9f0aac54f52218f9eac31b5cefa0f0144878b71435082
+      name: manager
+    - image: registry.redhat.io/openshift4/ose-kube-rbac-proxy-rhel9@sha256:29201e85bd41642b72c7c0ce915e40aad90823d0efc3e7bbab9c351c92c74341
+      name: kube-rbac-proxy
   version: 0.0.5
   webhookdefinitions:
     - admissionReviewVersions:

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -69,8 +69,13 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: metadata.namespace
-          - name: DEVICEFINDER_IMAGE
+        # Inject dependency images as env variables to instruct the operator-sdk to
+        # add them as relatedImages in the CSV. This information is required for disconnected environments.
+        # More info: https://docs.redhat.com/en/documentation/openshift_container_platform/4.18/html-single/operators/index#olm-enabling-operator-for-restricted-network_osdk-generating-csvs
+          - name: RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-DEVICEFINDER
             value: ${DEVICEFINDER_IMAGE}
+          - name: RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-MUST-GATHER
+            value: ${MUST_GATHER_IMAGE}
         securityContext:
           allowPrivilegeEscalation: false
           capabilities:
@@ -99,3 +104,4 @@ spec:
             memory: 64Mi
       serviceAccountName: controller-manager
       terminationGracePeriodSeconds: 10
+

--- a/config/manifests/bases/openshift-storage-scale-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/openshift-storage-scale-operator.clusterserviceversion.yaml
@@ -16,7 +16,9 @@ metadata:
     features.operators.openshift.io/token-auth-gcp: "false"
     operatorframework.io/initialization-resource: '{"apiVersion":"scale.storage.openshift.io/v1alpha1","kind":"StorageScale","metadata":{"name":"storagescale-sample"},"spec":{"ibm_cnsa_version":"v5.2.2.1","mco_config":{"create":true,"labels":{"machineconfiguration.openshift.io/role":"worker"}},"ibm_cnsa_cluster":{"create":true,"daemon_nodeSelector":{"node-role.kubernetes.io/worker":""}}}}'
     operatorframework.io/suggested-namespace: openshift-storage-scale
-    operators.openshift.io/valid-subscription: '["Openshift Container Platform"]'
+    operators.openshift.io/infrastructure-features: '["disconnected"]'
+    operators.openshift.io/valid-subscription: '["Openshift Container Platform","OpenShift
+      Virtualization Engine"]'
     operators.operatorframework.io/internal-objects: '["localvolumediscoveryresults.scale.storage.openshift.io","localvolumediscoveries.scale.storage.openshift.io"]'
   name: openshift-storage-scale-operator.v0.0.0
   namespace: placeholder

--- a/internal/common/names.go
+++ b/internal/common/names.go
@@ -13,8 +13,8 @@ const (
 	// OwnerNameLabel references the owning object
 	OwnerNameLabel = "scale.storage.openshift.io/owner-name"
 
-	// DeviceFinderImageEnv is used by the operator to read the DEVICEFINDER_IMAGE from the environment
-	DeviceFinderImageEnv = "DEVICEFINDER_IMAGE"
+	// DeviceFinderImageEnv is used by the operator to read the RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-DEVICEFINDER from the environment
+	DeviceFinderImageEnv = "RELATED_IMAGE_OPENSHIFT-STORAGE-SCALE-OPERATOR-DEVICEFINDER"
 	// KubeRBACProxyImageEnv is used by the operator to read the KUBE_RBAC_PROXY_IMAGE from the environment
 	KubeRBACProxyImageEnv = "KUBE_RBAC_PROXY_IMAGE"
 

--- a/scripts/ignore-createdAt-bundle.sh
+++ b/scripts/ignore-createdAt-bundle.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Since operator-sdk 1.26.0, `make bundle` changes the `createdAt` field from the bundle
+# even if it is patched:
+#   https://github.com/operator-framework/operator-sdk/pull/6136
+# This code checks if only the createdAt field. If is the only change, it is ignored.
+# Else, it will do nothing.
+# https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333
+git diff --quiet -I'^    createdAt: ' bundle
+if ((! $?)) ; then
+    git checkout bundle
+fi

--- a/scripts/storage-scale-operator-build.sh
+++ b/scripts/storage-scale-operator-build.sh
@@ -33,12 +33,12 @@ wait_for_resource() {
         fi
         ret=$?
         set -e
-        
+
         if [[ $ret -eq 0 && "$resource_type" != "csv" ]]; then
             echo "✅ $resource_type: $name is available!"
             break
         fi
-        
+
         sleep 10
     done
 }
@@ -80,7 +80,7 @@ if [[ -n $(git status --porcelain) ]]; then
     exit 1
 fi
 
-make VERSION=${VERSION} IMAGE_TAG_BASE=${REGISTRY}/openshift-storage-scale CHANNELS=fast \
+make VERSION=${VERSION} IMAGE_TAG_BASE=${REGISTRY}/openshift-storage-scale CHANNELS=fast USE_IMAGE_DIGESTS="" \
     manifests bundle generate docker-build docker-push bundle-build bundle-push console-build console-push \
     devicefinder-docker-build devicefinder-docker-push catalog-build catalog-push catalog-install
 


### PR DESCRIPTION
@mbaldessari @darkdoc PTAL.

I've added a script that will check if the bundle has changed at all, by ignoring the `createdAt` field. We could integrate this in the `build` github action in case we want to keep the bundle up to date on each build (the idea came from [here]( https://github.com/operator-framework/operator-sdk/issues/6285#issuecomment-1415350333))

Signed-off-by: Jordi Gil <jgil@redhat.com>
