### PR TITLE
Stop tagging devicefinder to latest as it is unneeded

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,11 +3,10 @@ set -e -o pipefail
 
 VERSION=$(cat VERSION.txt)
 
-make bundle generate manifests docker-build docker-push \
+make USE_IMAGE_DIGESTS="" bundle generate manifests docker-build docker-push \
     bundle-build bundle-push catalog-build catalog-push \
     console-build console-push devicefinder-docker-build devicefinder-docker-push
+
 podman tag quay.io/openshift-storage-scale/openshift-storage-scale-catalog:${VERSION} quay.io/openshift-storage-scale/openshift-storage-scale-catalog:stable
-podman tag quay.io/openshift-storage-scale/openshift-storage-scale-devicefinder:${VERSION} quay.io/openshift-storage-scale/openshift-storage-scale-devicefinder:latest
 
 podman push quay.io/openshift-storage-scale/openshift-storage-scale-catalog:stable
-podman push quay.io/openshift-storage-scale/openshift-storage-scale-devicefinder:latest


### PR DESCRIPTION
Also disable DIGESTS for when we release
